### PR TITLE
adjust retry mechanism to avoid infinite loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Clojure library for [Intercom's REST API](https://developers.intercom.com/refe
 1) Put the following dependency in your `project.clj`
 
 ```clj
-[intercom-clj "0.2.0"]
+[intercom-clj "0.2.4"]
 ```
 
 2) Set the  [Personal Access Token](https://developers.intercom.com/reference#section-using-personal-access-tokens) via:

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,5 +1,6 @@
 (ns user
   (:require [clojure.tools.namespace.repl :as tools]
+            [clojure.test :refer [run-all-tests run-tests]]
             [intercom-clj.core :refer [set-access-token!]]
             [intercom-clj.users :as users]
             [intercom-clj.events :as events]))

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject intercom-clj "0.2.3"
+(defproject intercom-clj "0.2.4"
   :description "A Clojure native library to use the Intercom REST API"
   :url "https://github.com/nanit/intercom-clj"
   :license {:name "Eclipse Public License"

--- a/src/intercom_clj/users.clj
+++ b/src/intercom_clj/users.clj
@@ -3,35 +3,35 @@
             [taoensso.timbre :refer [info] :as log])
   (:refer-clojure :exclude [update list]))
 
-(defn create 
-  "Create or updates a user" 
+(defn create
+  "Create or updates a user"
   [criteria]
   (POST "/users" criteria))
 
 (def update create)
 
-(defn show 
+(defn show
   "View a specific user by user_id or email fields
-   criteria examples: {:user_id 123} or {:email 'my@email.com'}" 
+   criteria examples: {:user_id 123} or {:email 'my@email.com'}"
   [criteria]
   (GET "/users" criteria))
 
-(defn show-by-id 
+(defn show-by-id
   "View a specific user by Intercom user ID"
   [id]
   (GET (format "/users/%s" id)))
 
-(defn list 
+(defn list
   "lists users
-  For arguments see https://developers.intercom.com/reference#list-users" 
+  For arguments see https://developers.intercom.com/reference#list-users"
   ([] (list {}))
   ([args] (GET "/users" args)))
 
-(defn scroll 
+(defn scroll
   "scrolls users
   docs: https://developers.intercom.com/intercom-api-reference/v1.0/reference#iterating-over-all-users"
   ([] (scroll nil))
-  ([scroll-param] 
+  ([scroll-param]
    (let [query-params (if scroll-param {:scroll_param scroll-param} {})]
      (GET "/users/scroll" query-params {:timeout 20000}))))
 
@@ -40,31 +40,40 @@
   Use page-limit to limit the number of scroll iterations
   Uses the scroll API
   docs: https://developers.intercom.com/intercom-api-reference/v1.0/reference#iterating-over-all-users"
-  ([] (all nil))
-  ([page-limit]
-   (loop [pages-left page-limit
-          acc []
-          scroll-param nil]
-     (info "INTERCOM_SCROLL_FETCHED" (count acc) "users")
-     (if (or (nil? pages-left) (> pages-left 0))
-       (let [{:keys [body status]} (scroll scroll-param)]
-         (if (= 200 status)
-           (let [users (:users body)]
-             (if (empty? users)
-               acc
-               (recur (when pages-left (dec pages-left))
-                      (vec (concat acc users))
-                      (:scroll_param body))))
-           (do (log/error "INTERCOM_REQUEST_FAILED" status body)
-               (Thread/sleep 3)
-               (recur pages-left
-                      acc
-                      scroll-param))))
-     acc))))
+  [& {:keys [retries-per-page page-limit]
+      :or   {retries-per-page 10}}]
+  (loop [pages-left   page-limit
+         acc          []
+         retries-left retries-per-page
+         scroll-param nil]
+    (info "INTERCOM_SCROLL_FETCHED" {:count (count acc)})
+    (if (or (nil? pages-left) (> pages-left 0))
+      (let [{:keys [body status]} (scroll scroll-param)]
+        (if (= status 200)
+          (let [users (:users body)]
+            (if (empty? users)
+              acc
+              (recur (when pages-left (dec pages-left))
+                     (vec (concat acc users))
+                     retries-per-page
+                     (:scroll_param body))))
+          (do (log/error "INTERCOM_REQUEST_FAILED" {:status status :body body})
+              (if (pos? retries-left)
+                (do
+                  (log/info "RETRYING" {:retries-left retries-left :retries-per-page retries-per-page})
+                  (Thread/sleep 150)
+                  (recur pages-left
+                         acc
+                         (dec retries-left)
+                         scroll-param))
+                (do
+                  (log/error "NO_MORE_RETRIES_LEFT")
+                  (throw (Exception. "INTERCOM_RETRIES_EXCEEDED")))))))
+      acc)))
 
 (defn delete
   "Deletes a user from Intercom
-   criteria examples: {:user_id 123} or {:email 'my@email.com'}" 
+   criteria examples: {:user_id 123} or {:email 'my@email.com'}"
   [criteria]
   (DELETE "/users" criteria))
 

--- a/test/intercom_clj/core_test.clj
+++ b/test/intercom_clj/core_test.clj
@@ -1,7 +1,0 @@
-(ns intercom-clj.core-test
-  (:require [clojure.test :refer :all]
-            [intercom-clj.core :refer :all]))
-
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))

--- a/test/intercom_clj/users_test.clj
+++ b/test/intercom_clj/users_test.clj
@@ -1,0 +1,75 @@
+(ns intercom-clj.users-test
+  (:require [intercom-clj.users :as users]
+            [clojure.test :refer :all]))
+
+(defn gen-responses [& responses]
+  (let [resps (atom responses)]
+    (fn [_]
+      (let [resp (first @resps)]
+        (swap! resps rest)
+        resp))))
+
+(deftest all-test
+  (testing "success"
+    (testing "no users should return empty collection of users"
+      (with-redefs [users/scroll (constantly {:status 200
+                                              :body   {:users []}})]
+        (is (empty? (users/all)))))
+
+    (testing "scrolling should stop on empty users and return list of users"
+      (with-redefs [users/scroll (gen-responses {:status 200
+                                                 :body   {:users        ["user"]
+                                                          :scroll_param "1"}}
+                                                {:status 200
+                                                 :body   {:users []}})]
+        (is (= ["user"] (users/all)))))
+    (testing "scrolling should return users on error during scrolling with retries more than failures"
+      (with-redefs [users/scroll (gen-responses {:status 200
+                                                 :body   {:users        ["user"]
+                                                          :scroll_param "1"}}
+                                                {:status 404
+                                                 :body   "doesn't matter..."}
+                                                {:status 404
+                                                 :body   "doesn't matter..."}
+                                                {:status 200
+                                                 :body   {:users        ["user2"]
+                                                          :scroll_param "1"}}
+                                                {:status 404
+                                                 :body   "doesn't matter..."}
+                                                {:status 404
+                                                 :body   "doesn't matter..."}
+                                                {:status 200
+                                                 :body   {:users []}})]
+        (is (= ["user" "user2"] (users/all :retries-per-page 2))))))
+  (testing "failure"
+    (testing "scrolling should stop and throw an exception on error with no retries"
+      (with-redefs [users/scroll (gen-responses {:status 404
+                                                 :body   "doesn't matter..."})]
+        (is (thrown? Exception (users/all :retries-per-page 0)))))
+    (testing "scrolling should stop and throw an exception on error during scrolling with retries less than failures"
+      (with-redefs [users/scroll (gen-responses {:status 200
+                                                 :body   {:users        ["user"]
+                                                          :scroll_param "1"}}
+                                                {:status 404
+                                                 :body   "doesn't matter..."}
+                                                {:status 404
+                                                 :body   "doesn't matter..."}
+                                                {:status 404
+                                                 :body   "doesn't matter..."}
+                                                {:status 200
+                                                 :body   {:users []}})]
+        (is (thrown? Exception (users/all :retries-per-page 2))))
+      (with-redefs [users/scroll (gen-responses {:status 200
+                                                 :body   {:users        ["user"]
+                                                          :scroll_param "1"}}
+                                                {:status 404
+                                                 :body   "doesn't matter..."}
+                                                {:status 200
+                                                 :body   {:users ["user2"]}}
+                                                {:status 404
+                                                 :body   "doesn't matter..."}
+                                                {:status 404
+                                                 :body   "doesn't matter..."}
+                                                {:status 404
+                                                 :body   "doesn't matter..."})]
+        (is (thrown? Exception (users/all :retries-per-page 2)))))))


### PR DESCRIPTION
We encounter an infinite loop while trying to fetch all users from intercom.

- added support for a retry mechanism that will stop retry loading a page after X failed attempts (10 by default).
- Increased timeout from 3ms to 150ms.
- added tests to the user listing function.

Inspired by @reutsharabani 's  PR https://github.com/nanit/intercom-clj/pull/3 ❤️ 